### PR TITLE
[Change]トップページのVTuberのお名前をやや中央揃いになるように修正

### DIFF
--- a/app/assets/stylesheets/arekore.scss
+++ b/app/assets/stylesheets/arekore.scss
@@ -53,8 +53,9 @@ ul.ui-autocomplete {
 }
 
 .index-name {
-  margin-inline: auto;
-  max-inline-size: max-content;
+  display: inline-block;
+  text-align: justify;
+  word-break: break-all;
 }
 
 .filtering_search_hover:hover {

--- a/app/views/vtubers/index.html.erb
+++ b/app/views/vtubers/index.html.erb
@@ -22,8 +22,10 @@
                     <%= image_tag vtuber.image.url, class: "rounded-circle border border-black", size: "250x250" %>
                 <% end %>
               </div>
-              <div class="mt-3 fs-2 text-body text-break index-name">
-                <%= vtuber.name %>
+              <div class="text-center">
+                <div class="mt-3 mx-3 fs-2 text-body index-name">
+                  <%= vtuber.name %>
+                </div>
               </div>
             </div>
           <% end %>


### PR DESCRIPTION
1行で収まる長さの名前は今回の修正前から中央揃いになっていたが、2行以上に渡る長さの名前は左寄せになっていた。
そのため、今回の対応ではどれほどの長さの名前でもやや中央揃いになるように修正した。

「やや中央揃い」としたのは完璧に中央揃いにすることはCSS的に限界があったからである。
というのも、日本語の場合は複数行でも完璧な中央揃いにできたのだが、英字の場合はそうはならなかった。
どうしても改行にあたり右端にわずかな空白が発生する。（marginによるものではない）
見た目は少しだけ左に寄っているように見えるが、実際は右端の空白のことを考慮すると完璧な中央揃いになっている。
